### PR TITLE
Add initial base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # base-image-dockers
 Base images for Auterion Applications
+
+Source for the base docker images you can used to build Applications for AuterionOS.
+
+Images currently supported:
+
+- Ubuntu 20.04 with Mavsdk (0.35.1) for Skynode (arm64) `docker pull auterion/ubuntu-mavsdk:0.35.1`
+- Debian Buster with Python and Mavsdk (0.15.0) for Skynode (arm64) `docker pull auterion/buster-python-mavsdk:0.15.0 `

--- a/mavsdk/v0.35.1/arm64v8/Dockerfile
+++ b/mavsdk/v0.35.1/arm64v8/Dockerfile
@@ -1,0 +1,23 @@
+FROM arm64v8/ubuntu as build-stage
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y \
+    build-essential \
+    git \
+    cmake \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    libtinyxml2-dev \
+    debhelper \
+    pkg-config \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /buildroot
+RUN git clone https://github.com/mavlink/MAVSDK.git -b v0.35.1 --recursive mavsdk
+RUN cd mavsdk && \
+    ./tools/generate_debian_changelog.sh > debian/changelog && \
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc -b
+RUN dpkg -i /buildroot/libmavsdk*.deb

--- a/python-mavsdk/0.15.0/arm64v8/Dockerfile.base
+++ b/python-mavsdk/0.15.0/arm64v8/Dockerfile.base
@@ -1,0 +1,8 @@
+FROM arm64v8/python:buster
+
+ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
+
+RUN apt update && apt install build-essential  \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install mavsdk


### PR DESCRIPTION
This PR introduces the following base images:
- Ubuntu 20.04 with Mavsdk (0.35.1) for Skynode (arm64)
- Debian Buster with Python and Mavsdk (0.15.0) for Skynode (arm64)