### PR TITLE
Add base images: mavsdk C++

### DIFF
--- a/mavsdk/develop/amd64/Dockerfile
+++ b/mavsdk/develop/amd64/Dockerfile
@@ -1,0 +1,23 @@
+FROM amd64/ubuntu as build-stage
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y \
+    build-essential \
+    git \
+    cmake \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    libtinyxml2-dev \
+    debhelper \
+    pkg-config \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /buildroot
+RUN git clone https://github.com/mavlink/MAVSDK.git -b develop --recursive mavsdk
+RUN cd mavsdk && \
+    ./tools/generate_debian_changelog.sh > debian/changelog && \
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc -b
+RUN dpkg -i /buildroot/libmavsdk*.deb

--- a/mavsdk/develop/arm64v8/Dockerfile
+++ b/mavsdk/develop/arm64v8/Dockerfile
@@ -1,0 +1,23 @@
+FROM arm64v8/ubuntu as build-stage
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y \
+    build-essential \
+    git \
+    cmake \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    libtinyxml2-dev \
+    debhelper \
+    pkg-config \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /buildroot
+RUN git clone https://github.com/mavlink/MAVSDK.git -b develop --recursive mavsdk
+RUN cd mavsdk && \
+    ./tools/generate_debian_changelog.sh > debian/changelog && \
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc -b
+RUN dpkg -i /buildroot/libmavsdk*.deb

--- a/mavsdk/v0.35.1/amd64/Dockerfile
+++ b/mavsdk/v0.35.1/amd64/Dockerfile
@@ -1,0 +1,23 @@
+FROM amd64/ubuntu as build-stage
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y \
+    build-essential \
+    git \
+    cmake \
+    libjsoncpp-dev \
+    libcurl4-openssl-dev \
+    libtinyxml2-dev \
+    debhelper \
+    pkg-config \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /buildroot
+RUN git clone https://github.com/mavlink/MAVSDK.git -b v0.35.1 --recursive mavsdk
+RUN cd mavsdk && \
+    ./tools/generate_debian_changelog.sh > debian/changelog && \
+	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc -b
+RUN dpkg -i /buildroot/libmavsdk*.deb


### PR DESCRIPTION
Add the following docker base images:
- mavsdk c++ v0.35.1 amd64 architecture
- mavsdk c++ develop arm64v8 architecture
- mavsdk c++ develop amd64 architecture