### PR TITLE
Optimize Python Mavsdk image

### DIFF
--- a/python-mavsdk/0.15.0/arm64v8/Dockerfile
+++ b/python-mavsdk/0.15.0/arm64v8/Dockerfile
@@ -1,0 +1,15 @@
+FROM arm64v8/ubuntu
+
+RUN apt update && apt install -y python3 python3-pip \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install protobuf jinja2 mavsdk==0.15.0 --target=/tmp
+WORKDIR /install
+RUN cp -r /tmp/mavsdk \
+    /tmp/aiogrpc \
+    /tmp/grpc \
+    /tmp/six.py \
+    /tmp/google \
+    /install
+RUN cp -r /install/ /usr/lib/python3/dist-packages/

--- a/python-mavsdk/0.15.0/arm64v8/Dockerfile.base
+++ b/python-mavsdk/0.15.0/arm64v8/Dockerfile.base
@@ -1,8 +1,0 @@
-FROM arm64v8/python:buster
-
-ENV GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS 8
-
-RUN apt update && apt install build-essential  \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN pip3 install mavsdk

--- a/python-mavsdk/0.16.1/arm64v8/Dockerfile
+++ b/python-mavsdk/0.16.1/arm64v8/Dockerfile
@@ -1,0 +1,15 @@
+FROM arm64v8/ubuntu
+
+RUN apt update && apt install -y python3 python3-pip \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install protobuf jinja2 mavsdk==0.16.1 --target=/tmp
+WORKDIR /install
+RUN cp -r /tmp/mavsdk \
+    /tmp/aiogrpc \
+    /tmp/grpc \
+    /tmp/six.py \
+    /tmp/google \
+    /install
+RUN cp -r /install/ /usr/lib/python3/dist-packages/

--- a/python-mavsdk/latest/arm64v8/Dockerfile
+++ b/python-mavsdk/latest/arm64v8/Dockerfile
@@ -1,0 +1,15 @@
+FROM arm64v8/ubuntu
+
+RUN apt update && apt install -y python3 python3-pip \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install protobuf jinja2 mavsdk --target=/tmp
+WORKDIR /install
+RUN cp -r /tmp/mavsdk \
+    /tmp/aiogrpc \
+    /tmp/grpc \
+    /tmp/six.py \
+    /tmp/google \
+    /install
+RUN cp -r /install/ /usr/lib/python3/dist-packages/


### PR DESCRIPTION
This PR introduces some optimizations to the Python MAVSDK image.
Now the image is based on `arm64v8/ubuntu`, we build mavsdk in `/tmp` folder and we install it on the image and also in `/install` so we could use the python mavsdk image in another Dockerfile to install mavsdk

```
COPY --from=auterion/ubuntu-python-mavsdk:latest /install /usr/lib/python3/dist-packages/
```